### PR TITLE
Padronização de frases com inicial maiúscula

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Verifica se número informado é um bilhete de identidade nacional.
 // GET https://angolaapi.herokuapp.com/api/v1/validate/bi/006151112LA041
 // Status: 200
 {
-  "message": "this is an Angola valid bi number"
+  "message": "This is an Angola valid bi number"
 }
 ```
 
@@ -472,7 +472,7 @@ Retorna se o registo informado é aceitavél como identificador de um passaporte
 // GET https://angolaapi.herokuapp.com/api/v1/validate/passport/n1234566
 // Status: 200
 {
-  "message": "this is an Angola valid passport number"
+  "message": "This is an Angola valid passport number"
 }
 ```
 
@@ -497,7 +497,7 @@ Verifica se o número informado é de Angola e a qual operadora pertence.
 // GET https://angolaapi.herokuapp.com/api/v1/validate/phone/+244923445618
 // Status: 200
 {
-  "message": "this is an Angola valid phone number",
+  "message": "This is an Angola valid phone number",
   "operator": "Unitel"
 }
 ```

--- a/src/useCases/validateBIUseCases/ValidateBiUseCase.ts
+++ b/src/useCases/validateBIUseCases/ValidateBiUseCase.ts
@@ -10,6 +10,6 @@ export class ValidateBiUseCase implements IvalidateBiUseCase {
 
     if (!this.validateBi.validate(bi)) throw new Error('Invalid bi number');
 
-    return 'this is an Angola valid bi number';
+    return 'This is an Angola valid bi number';
   }
 }

--- a/src/useCases/validatePassPortUseCase/ValidatePassPortUseCase.ts
+++ b/src/useCases/validatePassPortUseCase/ValidatePassPortUseCase.ts
@@ -11,6 +11,6 @@ export class ValidatePassPortUseCase implements IvalidatePassPortUseCase {
     if (!this.validatePassport.validate(passport))
       throw new Error('Invalid passport number');
 
-    return 'this is an Angola valid passport number';
+    return 'This is an Angola valid passport number';
   }
 }

--- a/src/useCases/validatePhoneUseCases/ValidatePhoneController.ts
+++ b/src/useCases/validatePhoneUseCases/ValidatePhoneController.ts
@@ -9,7 +9,7 @@ export class ValidatePhoneController {
       if (!request.params['phone'])
         return response.status(400).json({
           message:
-            'missing param error, you need to pass phone number on param',
+            'Missing param error, you need to pass phone number on param',
         });
 
       const { phone } = request.params;
@@ -17,7 +17,7 @@ export class ValidatePhoneController {
       const operator = this.validatePhoneUserCase.execute({ phone });
 
       return response.status(200).json({
-        message: 'this is an Angola valid phone number',
+        message: 'This is an Angola valid phone number',
         operator,
       });
     } catch (error) {


### PR DESCRIPTION
Algumas mensagens de retorno estavam iniciando a frase com letras minúsculas então decidi mudar para maiúsculas para padronizar com o restante do projeto.