### PR TITLE
refactor: refatorar o codigo de operador movel

### DIFF
--- a/src/lib/implementations/getOperator.ts
+++ b/src/lib/implementations/getOperator.ts
@@ -1,13 +1,23 @@
-import { Operator } from '../../constants';
 import { IgetOperator } from '../IgetOperator';
 
 export class GetOperator implements IgetOperator {
-  getOperator(phone: string): string {
-    const initial = parseInt(phone.substring(4, 6));
-    if (isNaN(initial)) return null;
-    if (initial === 91 || initial === 99) return Operator.Movicel;
-    if (initial > 91 && initial < 95) return Operator.Unitel;
-    if (initial === 95) return Operator.Africell;
-    return null;
+
+  private static readonly MobilePhoneOperators = {
+    "Movicel": [99, 91],
+    "Unitel": [92, 93, 94],
+    "Africell": [95]
+  }
+
+  getOperator(phone: string): string{
+    const prefix = parseInt(phone.substring(4, 6));
+      if (isNaN(prefix)) return null;
+
+      for (const operator in GetOperator.MobilePhoneOperators) {
+        if (GetOperator.MobilePhoneOperators[operator].includes(prefix)) {
+          return operator;
+        }
+      }
+
+      return null;
   }
 }


### PR DESCRIPTION
O objetivo desta PR é melhorar o algoritmo tornando mais performático e escalável, podemos utilizar um objeto **MobilePhoneOperators** que armazena as informações de cada operadora, mapeando os prefixos iniciais dos números para seus respectivos nomes. Desta forma, ao invés de realizar uma série de comparações com `if`.
 Com essa abordagem, o tempo de execução será constante, independentemente do número de operadoras.